### PR TITLE
fix: use ANTHROPIC_BASE_URL env var for custom Anthropic API endpoints

### DIFF
--- a/v2/src/core/agent-loop.mjs
+++ b/v2/src/core/agent-loop.mjs
@@ -240,7 +240,8 @@ async function callAnthropic(model, state, toolDefs, settings, stream) {
         body.thinking = { type: 'enabled', budget_tokens: settings.thinkingBudget || 10000 };
     }
 
-    const res = await fetch('https://api.anthropic.com/v1/messages', {
+    const baseUrl = process.env.ANTHROPIC_BASE_URL || 'https://api.anthropic.com';
+    const res = await fetch(`${baseUrl}/v1/messages`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
## Problem

The `callAnthropic` function in `v2/src/core/agent-loop.mjs` hardcodes the Anthropic API URL (`https://api.anthropic.com/v1/messages`), ignoring the `ANTHROPIC_BASE_URL` environment variable that is already documented in `env.mjs`.

This prevents users from pointing the CLI at custom/proxy Anthropic-compatible endpoints (e.g. local proxies, enterprise gateways).

## Fix

Read `ANTHROPIC_BASE_URL` from the environment and fall back to the default `https://api.anthropic.com` when not set — the same pattern already used for `OPENAI_BASE_URL` in the `callOpenAI` function.

## Changes

- `v2/src/core/agent-loop.mjs`: replaced hardcoded URL with `${baseUrl}/v1/messages` where `baseUrl = process.env.ANTHROPIC_BASE_URL || 'https://api.anthropic.com'`