### PR TITLE
fix(security): command injection, path traversal, SSRF, weak randomness

### DIFF
--- a/v2/src/hooks/engine.mjs
+++ b/v2/src/hooks/engine.mjs
@@ -121,6 +121,12 @@ export class HookEngine {
     /**
      * Execute a single hook. Supports command (shell) and function hooks.
      *
+     * Note: hook.command is an operator-configured shell string (defined in
+     * settings.json by the user who controls this machine) — it is intentionally
+     * executed as a shell command.  The tool input/context is passed ONLY via
+     * environment variables (never interpolated into the command string) to
+     * prevent escalation from tool input into the hook command itself.
+     *
      * @param {object} hook - hook definition
      * @param {object} context - execution context
      * @returns {Promise<object|null>}
@@ -128,10 +134,12 @@ export class HookEngine {
     async _executeHook(hook, context) {
         try {
             if (hook.command) {
+                // Ensure env values are strings (guards against prototype pollution
+                // or non-string values from context objects breaking child_process).
                 const env = {
                     ...process.env,
-                    HOOK_EVENT: context.event,
-                    HOOK_TOOL: context.toolName || '',
+                    HOOK_EVENT: String(context.event || ''),
+                    HOOK_TOOL: String(context.toolName || ''),
                     HOOK_INPUT: JSON.stringify(context.input || {}),
                 };
                 const output = execSync(hook.command, {

--- a/v2/src/permissions/ssrf-check.mjs
+++ b/v2/src/permissions/ssrf-check.mjs
@@ -1,0 +1,102 @@
+/**
+ * SSRF Protection — block requests to private/internal/loopback hosts.
+ *
+ * Prevents the WebFetch tool from being used as a Server-Side Request
+ * Forgery vector to probe internal network services, cloud metadata
+ * endpoints, or localhost.
+ *
+ * Covers:
+ * - Loopback: 127.0.0.0/8, ::1
+ * - Link-local: 169.254.0.0/16 (includes AWS/GCP/Azure metadata: 169.254.169.254)
+ * - Private ranges: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+ * - IPv6 private: fc00::/7 (ULA), fe80::/10 (link-local)
+ * - Unroutable: 0.0.0.0/8, 100.64.0.0/10 (CGNAT), 192.0.0.0/24
+ * - "localhost" and other reserved hostnames
+ */
+
+/** Hostnames that are unconditionally blocked. */
+const BLOCKED_HOSTNAMES = new Set([
+    'localhost',
+    'ip6-localhost',
+    'ip6-loopback',
+    'broadcasthost',
+    'metadata.google.internal',       // GCP metadata
+    'metadata.gcp.internal',
+]);
+
+/**
+ * Check whether a hostname resolves to a private or internal address.
+ * This operates purely on the literal hostname/IP string; it does NOT
+ * perform DNS resolution (to avoid TOCTOU races).
+ *
+ * @param {string} hostname - the hostname portion from a parsed URL
+ * @returns {boolean} true if the host should be blocked
+ */
+export function isPrivateHost(hostname) {
+    if (!hostname || typeof hostname !== 'string') return true;
+
+    const h = hostname.toLowerCase().trim();
+
+    // Block by hostname
+    if (BLOCKED_HOSTNAMES.has(h)) return true;
+
+    // Block *.local mDNS hostnames
+    if (h.endsWith('.local')) return true;
+
+    // Strip IPv6 brackets if present
+    const raw = h.startsWith('[') && h.endsWith(']') ? h.slice(1, -1) : h;
+
+    // IPv4 check
+    if (isIPv4(raw)) return isPrivateIPv4(raw);
+
+    // IPv6 check
+    if (isIPv6Like(raw)) return isPrivateIPv6(raw);
+
+    // Numeric decimal/hex/octal IP encodings (bypass attempts)
+    if (/^[0-9]+$/.test(raw) || /^0x[0-9a-f]+$/i.test(raw)) return true;
+
+    return false;
+}
+
+function isIPv4(s) {
+    return /^\d{1,3}(\.\d{1,3}){3}$/.test(s);
+}
+
+function isIPv6Like(s) {
+    return s.includes(':');
+}
+
+function isPrivateIPv4(ip) {
+    const parts = ip.split('.').map(Number);
+    if (parts.length !== 4 || parts.some(p => isNaN(p) || p < 0 || p > 255)) return true;
+    const [a, b, c] = parts;
+
+    if (a === 0) return true;                               // 0.0.0.0/8
+    if (a === 10) return true;                              // 10.0.0.0/8
+    if (a === 127) return true;                             // 127.0.0.0/8 loopback
+    if (a === 100 && b >= 64 && b <= 127) return true;     // 100.64.0.0/10 CGNAT
+    if (a === 169 && b === 254) return true;                // 169.254.0.0/16 link-local / metadata
+    if (a === 172 && b >= 16 && b <= 31) return true;      // 172.16.0.0/12 private
+    if (a === 192 && b === 0 && c === 0) return true;      // 192.0.0.0/24
+    if (a === 192 && b === 168) return true;                // 192.168.0.0/16 private
+    if (a === 198 && (b === 18 || b === 19)) return true;  // 198.18.0.0/15 benchmarking
+    if (a === 198 && b === 51 && c === 100) return true;   // 198.51.100.0/24 documentation
+    if (a === 203 && b === 0 && c === 113) return true;    // 203.0.113.0/24 documentation
+    if (a >= 224) return true;                             // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved
+
+    return false;
+}
+
+function isPrivateIPv6(ip) {
+    const lower = ip.toLowerCase();
+    if (lower === '::1') return true;                  // loopback
+    if (lower === '::') return true;                   // unspecified
+    if (lower.startsWith('::ffff:')) {                 // IPv4-mapped
+        const v4 = lower.slice(7);
+        if (isIPv4(v4)) return isPrivateIPv4(v4);
+    }
+    if (lower.startsWith('fe80:')) return true;        // fe80::/10 link-local
+    if (lower.startsWith('fc') || lower.startsWith('fd')) return true; // fc00::/7 ULA
+    if (lower.startsWith('ff')) return true;           // multicast
+    return false;
+}

--- a/v2/src/plugins/loader.mjs
+++ b/v2/src/plugins/loader.mjs
@@ -8,7 +8,7 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 export class PluginLoader {
     /**
@@ -62,18 +62,26 @@ export class PluginLoader {
      * @returns {object|null} loaded manifest
      */
     async loadFromGit(repoUrl, name) {
+        // Security: validate repoUrl to only allow https:// or ssh git URLs,
+        // preventing shell metacharacter injection when passed to execFileSync.
+        if (typeof repoUrl !== 'string' ||
+            !/^(https?:\/\/|git@)[^\s;|&`$<>'"\\]+$/.test(repoUrl)) {
+            return null;
+        }
         const pluginName = name || repoUrl.split('/').pop()?.replace('.git', '') || 'plugin';
-        const targetDir = path.join(this.pluginDir, pluginName);
+        // Normalize plugin name to alphanumeric + hyphens only
+        const safePluginName = pluginName.replace(/[^a-zA-Z0-9_-]/g, '_');
+        const targetDir = path.join(this.pluginDir, safePluginName);
 
         try {
             fs.mkdirSync(this.pluginDir, { recursive: true });
 
             if (fs.existsSync(targetDir)) {
-                // Update existing
-                execSync('git pull', { cwd: targetDir, stdio: 'pipe' });
+                // Update existing — cwd is explicit, no user data in args
+                execFileSync('git', ['pull'], { cwd: targetDir, stdio: 'pipe' });
             } else {
-                // Clone new
-                execSync(`git clone --depth 1 ${repoUrl} ${targetDir}`, { stdio: 'pipe' });
+                // Clone new — repoUrl and targetDir passed as discrete args, not shell string
+                execFileSync('git', ['clone', '--depth', '1', repoUrl, targetDir], { stdio: 'pipe' });
             }
 
             const manifestPath = path.join(targetDir, 'plugin.json');

--- a/v2/src/tools/enter-worktree.mjs
+++ b/v2/src/tools/enter-worktree.mjs
@@ -4,7 +4,7 @@
  * Creates a temporary worktree branch so edits do not affect the main branch.
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import path from 'path';
 import os from 'os';
 
@@ -38,7 +38,8 @@ export const EnterWorktreeTool = {
 
         try {
             // Verify we are in a git repo
-            execSync('git rev-parse --is-inside-work-tree', { encoding: 'utf-8' });
+            // Security: execFileSync so arguments are not shell-interpolated
+            execFileSync('git', ['rev-parse', '--is-inside-work-tree'], { encoding: 'utf-8' });
         } catch {
             return 'Error: not inside a git repository';
         }
@@ -48,7 +49,8 @@ export const EnterWorktreeTool = {
         const originalCwd = process.cwd();
 
         try {
-            execSync(`git worktree add -b "${branch}" "${worktreePath}"`, {
+            // Security: pass branch and worktreePath as discrete args — no shell injection
+            execFileSync('git', ['worktree', 'add', '-b', branch, worktreePath], {
                 encoding: 'utf-8',
                 stdio: 'pipe',
             });

--- a/v2/src/tools/exit-worktree.mjs
+++ b/v2/src/tools/exit-worktree.mjs
@@ -2,7 +2,7 @@
  * ExitWorktree Tool — exit and clean up a git worktree.
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 export const ExitWorktreeTool = {
     name: 'ExitWorktree',
@@ -35,11 +35,12 @@ export const ExitWorktreeTool = {
 
             if (cleanup) {
                 try {
-                    execSync(`git worktree remove "${wt.path}" --force`, {
+                    // Security: pass path and branch as discrete args — no shell injection
+                    execFileSync('git', ['worktree', 'remove', wt.path, '--force'], {
                         encoding: 'utf-8',
                         stdio: 'pipe',
                     });
-                    execSync(`git branch -D "${wt.branch}"`, {
+                    execFileSync('git', ['branch', '-D', wt.branch], {
                         encoding: 'utf-8',
                         stdio: 'pipe',
                     });

--- a/v2/src/tools/grep.mjs
+++ b/v2/src/tools/grep.mjs
@@ -9,8 +9,11 @@
  * - glob filter and type filter
  * - head_limit (default 250)
  * - multiline mode
+ *
+ * Security: uses execFileSync (array-based) so pattern, glob, type, and dir
+ * are never interpolated into a shell string — no command injection.
  */
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import path from 'path';
 
 export const GrepTool = {
@@ -96,16 +99,28 @@ export const GrepTool = {
                 args.push('--', input.pattern, dir);
             }
 
-            // Apply head_limit
-            const cmd = limit > 0
-                ? `${args.join(' ')} 2>/dev/null | head -${limit}`
-                : `${args.join(' ')} 2>/dev/null`;
+            // args[0] is the tool name (rg/grep); the rest are arguments.
+            // Use execFileSync so nothing is shell-interpolated.
+            const tool = args.shift(); // 'rg' or 'grep'
+            let result;
+            try {
+                result = execFileSync(tool, args, {
+                    encoding: 'utf-8',
+                    maxBuffer: 10 * 1024 * 1024,
+                    timeout: 30000,
+                });
+            } catch (e) {
+                // exit code 1 from grep/rg means no matches — not an error
+                result = e.stdout || '';
+            }
 
-            const result = execSync(cmd, {
-                encoding: 'utf-8',
-                maxBuffer: 10 * 1024 * 1024,
-                timeout: 30000,
-            });
+            // Apply head_limit by slicing lines in JS (no shell pipe needed)
+            if (limit > 0) {
+                const lines = result.split('\n');
+                if (lines.length > limit) {
+                    result = lines.slice(0, limit).join('\n');
+                }
+            }
 
             return result.trim() || 'No matches found.';
         } catch {
@@ -118,7 +133,7 @@ let _hasRg = null;
 function hasRipgrep() {
     if (_hasRg !== null) return _hasRg;
     try {
-        execSync('which rg', { encoding: 'utf-8', timeout: 5000 });
+        execFileSync('which', ['rg'], { encoding: 'utf-8', timeout: 5000 });
         _hasRg = true;
     } catch {
         _hasRg = false;

--- a/v2/src/tools/lsp.mjs
+++ b/v2/src/tools/lsp.mjs
@@ -12,7 +12,7 @@
  * server process and communicate via JSON-RPC.
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import path from 'path';
 
 export const LspTool = {
@@ -78,21 +78,35 @@ function getDiagnostics(filePath, language) {
     const ext = path.extname(filePath);
     const lang = language || extToLanguage(ext);
 
+    // Security: use execFileSync with explicit args arrays so filePath is
+    // never shell-interpolated — no command injection via crafted file names.
     try {
         switch (lang) {
             case 'typescript':
             case 'javascript': {
-                const result = execSync(
-                    `npx tsc --noEmit --pretty false "${filePath}" 2>&1 || true`,
-                    { encoding: 'utf-8', timeout: 15000 }
-                );
+                let result = '';
+                try {
+                    result = execFileSync(
+                        'npx',
+                        ['tsc', '--noEmit', '--pretty', 'false', filePath],
+                        { encoding: 'utf-8', timeout: 15000 }
+                    );
+                } catch (e) {
+                    result = e.stdout || e.stderr || '';
+                }
                 return result.trim() || 'No diagnostics.';
             }
             case 'python': {
-                const result = execSync(
-                    `python3 -m py_compile "${filePath}" 2>&1 || true`,
-                    { encoding: 'utf-8', timeout: 10000 }
-                );
+                let result = '';
+                try {
+                    result = execFileSync(
+                        'python3',
+                        ['-m', 'py_compile', filePath],
+                        { encoding: 'utf-8', timeout: 10000 }
+                    );
+                } catch (e) {
+                    result = e.stderr || e.stdout || '';
+                }
                 return result.trim() || 'No diagnostics.';
             }
             default:

--- a/v2/src/tools/read.mjs
+++ b/v2/src/tools/read.mjs
@@ -11,7 +11,7 @@
  */
 import fs from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 const DEFAULT_LIMIT = 2000;
 
@@ -118,20 +118,26 @@ export const ReadTool = {
 
 function readPdf(filePath, pages) {
     // PDF reading requires external tools; provide a best-effort
-    // text extraction using a simple approach
+    // text extraction using a simple approach.
+    // Security: use execFileSync with an explicit args array so filePath and
+    // page numbers are never shell-interpolated (no injection possible).
     try {
-        // Sanitize filePath for shell use
-        const safePath = filePath.replace(/'/g, "'\\''");
-        let pageArg = '-f 1 -l 20';
+        const args = [];
         if (pages) {
             const parts = pages.split('-');
             const first = parseInt(parts[0], 10);
             const last = parseInt(parts[parts.length - 1], 10);
             if (!isNaN(first) && !isNaN(last) && first > 0 && last >= first) {
-                pageArg = `-f ${first} -l ${last}`;
+                args.push('-f', String(first), '-l', String(last));
+            } else {
+                args.push('-f', '1', '-l', '20');
             }
+        } else {
+            args.push('-f', '1', '-l', '20');
         }
-        const text = execSync(`pdftotext ${pageArg} '${safePath}' - 2>/dev/null`, {
+        args.push(filePath, '-');
+
+        const text = execFileSync('pdftotext', args, {
             encoding: 'utf-8',
             timeout: 30000,
             maxBuffer: 1024 * 1024,

--- a/v2/src/tools/send-message.mjs
+++ b/v2/src/tools/send-message.mjs
@@ -5,6 +5,8 @@
  * Messages are stored in a shared message queue.
  */
 
+import { randomBytes } from 'crypto';
+
 const messageQueue = new Map(); // agentId -> messages[]
 
 export const SendMessageTool = {
@@ -38,8 +40,10 @@ export const SendMessageTool = {
     },
 
     async call(input) {
+        // Use cryptographically secure random bytes for message IDs to
+        // prevent guessing/enumeration of message identifiers.
         const msg = {
-            id: `msg_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+            id: `msg_${Date.now()}_${randomBytes(6).toString('hex')}`,
             from: process.env.AGENT_ID || 'main',
             to: input.to,
             type: input.type || 'notification',

--- a/v2/src/tools/web-fetch.mjs
+++ b/v2/src/tools/web-fetch.mjs
@@ -1,6 +1,12 @@
 /**
  * Web Fetch Tool — fetch URL content using built-in Node.js fetch.
+ *
+ * Security: validates the URL before fetching to prevent SSRF attacks.
+ * Private/link-local/loopback addresses and cloud metadata endpoints are
+ * blocked so the tool cannot be used to probe internal network services.
  */
+
+import { isPrivateHost } from '../permissions/ssrf-check.mjs';
 
 export const WebFetchTool = {
     name: 'WebFetch',
@@ -29,6 +35,10 @@ export const WebFetchTool = {
             // Only allow http and https protocols
             if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
                 errors.push('url must use http or https protocol');
+            }
+            // Block SSRF: reject private/internal/loopback hosts
+            if (isPrivateHost(parsed.hostname)) {
+                errors.push('url must not target private or internal network addresses');
             }
         } catch {
             errors.push('url must be a valid URL');

--- a/v2/src/tools/web-search.mjs
+++ b/v2/src/tools/web-search.mjs
@@ -5,7 +5,11 @@
  * - Brave Search API (BRAVE_API_KEY)
  * - SearXNG (self-hosted, SEARXNG_URL)
  * - Fallback: returns instructions to use web-fetch instead
+ *
+ * Security: validates that SEARXNG_URL does not target private/internal
+ * addresses (SSRF guard) before making requests.
  */
+import { isPrivateHost } from '../permissions/ssrf-check.mjs';
 
 export const WebSearchTool = {
     name: 'WebSearch',
@@ -32,9 +36,17 @@ export const WebSearchTool = {
             return searchBrave(input.query, limit, braveKey);
         }
 
-        // Try SearXNG
+        // Try SearXNG — validate the configured URL is not an internal host
         const searxUrl = process.env.SEARXNG_URL;
         if (searxUrl) {
+            try {
+                const parsed = new URL(searxUrl);
+                if (isPrivateHost(parsed.hostname)) {
+                    return 'SEARXNG_URL points to a private/internal address. Configure a public SearXNG instance.';
+                }
+            } catch {
+                return 'SEARXNG_URL is not a valid URL.';
+            }
             return searchSearxng(input.query, limit, searxUrl);
         }
 

--- a/v2/src/ui/commands.mjs
+++ b/v2/src/ui/commands.mjs
@@ -443,10 +443,13 @@ export const COMMANDS = {
         description: 'Create a git commit with AI message',
         handler(args) {
             try {
-                const { execSync } = require('child_process');
+                // Security: use execFileSync with discrete args so the commit
+                // message is never shell-interpolated (prevents injection via
+                // crafted message strings containing shell metacharacters).
+                const { execFileSync } = require('child_process');
                 const msg = args || 'Update from open-claude-code';
-                execSync('git add -A', { encoding: 'utf-8' });
-                execSync(`git commit -m "${msg}"`, { encoding: 'utf-8' });
+                execFileSync('git', ['add', '-A'], { encoding: 'utf-8' });
+                execFileSync('git', ['commit', '-m', msg], { encoding: 'utf-8' });
                 return `Committed: ${msg}`;
             } catch (err) {
                 return `Commit failed: ${err.message}`;


### PR DESCRIPTION
## Summary

Static security audit of `v2/src/` found and fixed the following issues:

- **Command injection (CWE-78)** — 6 files used `execSync` with user-controlled strings interpolated into shell template literals. Replaced with `execFileSync` + explicit arg arrays throughout: `grep.mjs`, `lsp.mjs`, `enter-worktree.mjs`, `exit-worktree.mjs`, `plugins/loader.mjs`, `commands.mjs` (`/commit` handler).
- **Path traversal / shell injection in PDF handler** — `read.mjs` used single-quote escaping (`replace(/'/g, "'\\''")`), which is bypassable. Replaced with `execFileSync('pdftotext', [args..., filePath, '-'])`.
- **SSRF (CWE-918)** — `web-fetch.mjs` fetched any user-supplied URL with no IP range restriction. Added a new `permissions/ssrf-check.mjs` module that blocks loopback (127.0.0.0/8, ::1), link-local/metadata (169.254.0.0/16), all RFC 1918 private ranges, CGNAT (100.64/10), and IPv6 ULA/link-local. Wired into `validateInput` so blocked URLs are rejected before any network call.
- **SSRF in SearXNG search** — `web-search.mjs` passed `SEARXNG_URL` to `fetch` without validating it wasn't an internal host. Added the same `isPrivateHost` check.
- **Weak randomness for message IDs (CWE-338)** — `send-message.mjs` used `Math.random()` for message identifiers. Replaced with `crypto.randomBytes(6).toString('hex')`.
- **Unvalidated git repo URL** — `plugins/loader.mjs` passed an unsanitised `repoUrl` to `git clone` via shell string. Added format validation (only `https://` or `git@` prefixes, no shell metacharacters allowed) plus normalization of derived plugin directory names.
- **Hooks engine env hardening** — `HOOK_EVENT` and `HOOK_TOOL` env values now coerced to `String()` before being spread into the child process environment.

## Test plan

- [x] All 904 existing unit tests pass (`node v2/test/test.mjs`: 904 passed, 0 failed)
- [x] `npm audit` in `v2/` reports 0 vulnerabilities
- [x] No secrets or `.env` files committed
- [x] New `ssrf-check.mjs` covers IPv4, IPv6, hostname, and bypass encodings (decimal/hex/octal IPs)

## Files changed

| File | Issue fixed |
|------|------------|
| `v2/src/tools/grep.mjs` | Command injection via `pattern`/`glob`/`dir` in shell string |
| `v2/src/tools/lsp.mjs` | Command injection via `filePath` in shell string |
| `v2/src/tools/read.mjs` | Path traversal / shell injection in PDF handler |
| `v2/src/tools/enter-worktree.mjs` | Command injection via `branch`/`worktreePath` |
| `v2/src/tools/exit-worktree.mjs` | Command injection via `wt.path`/`wt.branch` |
| `v2/src/plugins/loader.mjs` | Command injection via unvalidated `repoUrl` in `git clone` |
| `v2/src/ui/commands.mjs` | Command injection via commit message in `/commit` handler |
| `v2/src/tools/web-fetch.mjs` | SSRF — no private IP validation |
| `v2/src/tools/web-search.mjs` | SSRF — SEARXNG_URL not validated |
| `v2/src/permissions/ssrf-check.mjs` | New: SSRF private-host blocklist module |
| `v2/src/tools/send-message.mjs` | Weak randomness for message IDs |
| `v2/src/hooks/engine.mjs` | Env var type safety in hook execution |

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)