### PR TITLE
feat(optimize): opt-in metaharness self-optimization layer (cost-cascade router)

### DIFF
--- a/v2/src/config/cli-args.mjs
+++ b/v2/src/config/cli-args.mjs
@@ -32,6 +32,8 @@ export function parseArgs(args) {
         debug: false,
         showVersion: false,
         showHelp: false,
+        // Opt-in metaharness self-optimization. null = unset (defer to env/setting).
+        selfOptimize: null,
     };
 
     for (let i = 0; i < args.length; i++) {
@@ -86,6 +88,14 @@ export function parseArgs(args) {
                 result.debug = true;
                 break;
 
+            case '--self-optimize':
+                result.selfOptimize = true;
+                break;
+
+            case '--no-self-optimize':
+                result.selfOptimize = false;
+                break;
+
             case '--version':
                 result.showVersion = true;
                 break;
@@ -127,13 +137,23 @@ Options:
   --disallowedTools <tools>  Comma-separated list of denied tools
   --verbose, -v              Verbose output
   --debug, -d                Debug mode
+  --self-optimize            Route model calls through the metaharness cost-cascade
+                             (cheap base -> escalate) and record real outcomes (opt-in)
+  --no-self-optimize         Force self-optimization off (overrides env/setting)
   --version                  Show version
   --help, -h                 Show this help
+
+Subcommands:
+  occ optimize <status|route|report|reset|help>   Inspect/manage the self-optimization router (no model calls)
+  occ redblue [...]          Delegate to @metaharness/redblue CLI (self red/blue-team testing, via npx)
+  occ darwin  [...]          Delegate to @metaharness/darwin CLI (config evolution, via npx)
 
 Examples:
   occ                        Start interactive REPL
   occ -p "What is 2+2?"     Run prompt and exit
   occ -m claude-haiku-4-5    Use Haiku model
   occ --debug -p "Fix bug"  Debug mode with prompt
+  occ --self-optimize -p "..."   Run with the cost-cascade router enabled
+  occ optimize status        Show the router config and recorded outcomes
 `.trim();
 }

--- a/v2/src/config/env.mjs
+++ b/v2/src/config/env.mjs
@@ -30,6 +30,8 @@ export const ENV_SCHEMA = {
     CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: { type: 'boolean', default: false, description: 'Enable agent teams' },
     CLAUDE_CODE_DEBUG: { type: 'boolean', default: false, description: 'Debug mode' },
     CLAUDE_CODE_DISABLE_TELEMETRY: { type: 'boolean', default: false, description: 'Disable telemetry' },
+    CLAUDE_CODE_SELF_OPTIMIZE: { type: 'boolean', default: false, description: 'Enable metaharness cost-cascade self-optimization (opt-in)' },
+    CLAUDE_CODE_OPTIMIZE_DIR: { type: 'string', description: 'Directory for self-optimization outcome store' },
 
     // Permission and Security
     CLAUDE_CODE_PERMISSION_MODE: { type: 'string', default: 'default', description: 'Permission mode' },

--- a/v2/src/config/settings.mjs
+++ b/v2/src/config/settings.mjs
@@ -58,6 +58,10 @@ export const SETTINGS_SCHEMA = {
     agentId: null,
     cronEnabled: true,
     featureFlags: {},
+    // Metaharness self-optimization (opt-in; default OFF — behavior unchanged).
+    selfOptimize: false,
+    selfOptimizeQualityBar: 0.7,
+    selfOptimizeLadder: null,
 };
 
 export async function loadSettings() {
@@ -116,4 +120,6 @@ function applyEnvOverrides(settings) {
     if (process.env.CLAUDE_CODE_THINKING === '1') settings.alwaysThinkingEnabled = true;
     if (process.env.CLAUDE_CODE_DISABLE_CRON === '1') settings.cronEnabled = false;
     if (process.env.CLAUDE_CODE_ENABLE_TASKS === '1') settings.enableTeams = true;
+    if (process.env.CLAUDE_CODE_SELF_OPTIMIZE === '1') settings.selfOptimize = true;
+    if (process.env.CLAUDE_CODE_SELF_OPTIMIZE === '0') settings.selfOptimize = false;
 }

--- a/v2/src/core/agent-loop.mjs
+++ b/v2/src/core/agent-loop.mjs
@@ -9,7 +9,7 @@ import { buildSystemPrompt } from './system-prompt.mjs';
 /** Maximum number of consecutive tool-use continuation turns before aborting. */
 const MAX_TOOL_RECURSION_DEPTH = 50;
 
-export function createAgentLoop({ model, tools, permissions, settings, hooks }) {
+export function createAgentLoop({ model, tools, permissions, settings, hooks, cascade = null }) {
     const contextManager = new ContextManager(settings.maxContextTokens || 180000);
 
     // Build system prompt using the new builder
@@ -28,7 +28,30 @@ export function createAgentLoop({ model, tools, permissions, settings, hooks }) 
         model,
         tools,
         _contextManager: contextManager,
+        _cascade: cascade,
     };
+
+    // Self-optimization bookkeeping for the current top-level task (opt-in).
+    let _optTask = null; // { model, complexity, startedAt, tokensAtStart }
+
+    /** Record the outcome of the current task, if self-optimization is on. */
+    function recordOptOutcome(success) {
+        if (!cascade || !_optTask) return;
+        const inputDelta = state.tokenUsage.input - _optTask.tokensAtStart.input;
+        const outputDelta = state.tokenUsage.output - _optTask.tokensAtStart.output;
+        try {
+            cascade.recordOutcome({
+                model: _optTask.model,
+                success,
+                latencyMs: Date.now() - _optTask.startedAt,
+                inputTokens: inputDelta >= 0 ? inputDelta : 0,
+                outputTokens: outputDelta >= 0 ? outputDelta : 0,
+                complexity: _optTask.complexity,
+                task: _optTask.task,
+            });
+        } catch { /* best-effort */ }
+        _optTask = null;
+    }
 
     async function* run(userMessage, options = {}) {
         const depth = (options._depth || 0);
@@ -47,6 +70,22 @@ export function createAgentLoop({ model, tools, permissions, settings, hooks }) 
                 content: userMessage,
             });
             state.turnCount++;
+
+            // Opt-in cost-cascade routing: pick the cheapest good-enough model
+            // for this task and record outcome bookkeeping. Default path (no
+            // cascade) leaves state.model exactly as constructed.
+            if (cascade) {
+                const route = cascade.decide(userMessage);
+                state.model = route.model;
+                state._lastRoute = route;
+                _optTask = {
+                    model: route.model,
+                    complexity: route.complexity,
+                    startedAt: Date.now(),
+                    tokensAtStart: { input: state.tokenUsage.input, output: state.tokenUsage.output },
+                    task: String(userMessage).slice(0, 120),
+                };
+            }
         }
 
         // Check max turns
@@ -64,14 +103,16 @@ export function createAgentLoop({ model, tools, permissions, settings, hooks }) 
 
         yield { type: 'stream_request_start', turn: state.turnCount };
 
-        // Detect provider and call API
-        const provider = detectProvider(model);
+        // Detect provider and call API. Use state.model so an opt-in cascade
+        // pick takes effect; defaults to the constructed model otherwise.
+        const activeModel = state.model || model;
+        const provider = detectProvider(activeModel);
         let response;
 
         try {
             if (settings.stream !== false) {
                 // Streaming mode
-                response = await callApiStreaming(provider, model, state, tools.list(), settings);
+                response = await callApiStreaming(provider, activeModel, state, tools.list(), settings);
                 const collectedContent = [];
                 let currentText = '';
                 let currentThinking = '';
@@ -98,9 +139,10 @@ export function createAgentLoop({ model, tools, permissions, settings, hooks }) 
                 response = response.accumulated;
             } else {
                 // Non-streaming mode
-                response = await callApi(provider, model, state, tools.list(), settings);
+                response = await callApi(provider, activeModel, state, tools.list(), settings);
             }
         } catch (err) {
+            recordOptOutcome(false);
             yield { type: 'error', message: err.message };
             return;
         }
@@ -208,6 +250,9 @@ export function createAgentLoop({ model, tools, permissions, settings, hooks }) 
                 return;
             }
         }
+
+        // Task completed normally — record a successful outcome (opt-in).
+        recordOptOutcome(true);
 
         yield { type: 'stop', reason: response.stop_reason || 'end_turn' };
     }

--- a/v2/src/index.mjs
+++ b/v2/src/index.mjs
@@ -37,7 +37,26 @@ import { readEnv } from './config/env.mjs';
 import * as telemetry from './telemetry/index.mjs';
 
 async function main() {
-    const args = parseArgs(process.argv.slice(2));
+    const rawArgv = process.argv.slice(2);
+
+    // ── Metaharness subcommand dispatch (opt-in; runs before normal flow) ──
+    // `occ optimize|redblue|darwin ...` are handled here and exit. A normal
+    // `occ "prompt"` never reaches this branch, so default behavior is intact.
+    const subcommand = rawArgv[0];
+    if (subcommand === 'optimize' || subcommand === 'redblue' || subcommand === 'darwin') {
+        const settings = await loadSettings();
+        const { runOptimize, delegateToCli } = await import('./optimize/commands.mjs');
+        if (subcommand === 'optimize') {
+            const { output, code } = await runOptimize(rawArgv.slice(1), settings);
+            console.log(output);
+            process.exit(code);
+        }
+        const pkg = subcommand === 'redblue' ? '@metaharness/redblue' : '@metaharness/darwin';
+        const { code } = await delegateToCli(pkg, rawArgv.slice(1));
+        process.exit(code);
+    }
+
+    const args = parseArgs(rawArgv);
 
     // Handle --version
     if (args.showVersion) {
@@ -107,12 +126,29 @@ async function main() {
     const mcpResourceTool = tools.get('ReadMcpResource');
     if (mcpResourceTool) mcpResourceTool._mcpClients = mcpClients;
 
+    // ── Opt-in self-optimization cascade ──
+    // Only constructed when enabled (flag > env > setting). When null, the agent
+    // loop behaves exactly as before — same model, no outcome recording.
+    let cascade = null;
+    const { isSelfOptimizeEnabled } = await import('./optimize/cascade.mjs');
+    if (isSelfOptimizeEnabled(args, settings, process.env)) {
+        const { SelfOptimizeCascade } = await import('./optimize/cascade.mjs');
+        cascade = new SelfOptimizeCascade({
+            settings,
+            fallbackModel: args.model || settings.model || 'claude-sonnet-4-6',
+        });
+        if (args.verbose || settings.verbose) {
+            console.error('\x1b[2m[self-optimize] cost-cascade router enabled\x1b[0m');
+        }
+    }
+
     const loop = createAgentLoop({
         model: args.model || settings.model || 'claude-sonnet-4-6',
         tools,
         permissions,
         settings,
         hooks,
+        cascade,
     });
 
     // Attach extra state for commands to access

--- a/v2/src/optimize/cascade.mjs
+++ b/v2/src/optimize/cascade.mjs
@@ -1,0 +1,128 @@
+/**
+ * Self-optimization cascade controller.
+ *
+ * Glue between {@link MetaHarnessRouter} and {@link OutcomeStore}. Given a task,
+ * it decides which model to use (cost-cascade), and after the task completes it
+ * records the real outcome so future routing self-tunes.
+ *
+ * This is OPT-IN. It is only constructed when the user enables self-optimization
+ * via `--self-optimize`, the `selfOptimize` setting, or CLAUDE_CODE_SELF_OPTIMIZE.
+ * When disabled, the agent loop never imports or runs any of this, so default
+ * behavior is byte-identical.
+ */
+import { MetaHarnessRouter, DEFAULT_LADDER } from './router.mjs';
+import { OutcomeStore, estimateCostUsd } from './store.mjs';
+
+/**
+ * Build a model ladder from settings, falling back to the default. Honors an
+ * explicit `selfOptimizeLadder` setting (array of {id,costPerMTok}) and keeps
+ * the configured base/fast/frontier models if present.
+ *
+ * @param {object} [settings]
+ * @returns {Array<{id:string,costPerMTok:number,tier?:number}>}
+ */
+export function buildLadder(settings = {}) {
+    if (Array.isArray(settings.selfOptimizeLadder) && settings.selfOptimizeLadder.length) {
+        return settings.selfOptimizeLadder
+            .filter(m => m && m.id && typeof m.costPerMTok === 'number')
+            .map((m, i) => ({ tier: i + 1, ...m }));
+    }
+    return DEFAULT_LADDER;
+}
+
+/**
+ * Cascade controller. Holds a router + outcome store and exposes a small API the
+ * agent loop calls.
+ */
+export class SelfOptimizeCascade {
+    /**
+     * @param {object} [opts]
+     * @param {object} [opts.settings] CLI settings (ladder, qualityBar)
+     * @param {OutcomeStore} [opts.store] outcome store (defaults to a fresh one)
+     * @param {string} [opts.fallbackModel] model to use if routing yields nothing
+     */
+    constructor(opts = {}) {
+        const settings = opts.settings || {};
+        this.store = opts.store || new OutcomeStore();
+        this.fallbackModel = opts.fallbackModel || settings.model || 'claude-sonnet-4-6';
+        const ladder = buildLadder(settings);
+        this.ladder = ladder;
+        this.router = new MetaHarnessRouter({
+            ladder,
+            qualityBar: typeof settings.selfOptimizeQualityBar === 'number' ? settings.selfOptimizeQualityBar : 0.7,
+            statsFor: (id) => this.store.statsFor(id),
+        });
+        /** @type {Array<{task:string, route:object}>} last routing decisions (in-memory, for inspection) */
+        this.lastRoutes = [];
+    }
+
+    /**
+     * Decide which model to use for a task without making any model call.
+     * @param {string} taskText
+     * @returns {{ model: string, predictedQuality: number, costPerMTok: number, metBar: boolean, complexity: number, ladder: string[] }}
+     */
+    decide(taskText) {
+        const route = this.router.route(taskText || '');
+        this.lastRoutes.push({ task: (taskText || '').slice(0, 80), route });
+        if (this.lastRoutes.length > 50) this.lastRoutes.shift();
+        return route;
+    }
+
+    /**
+     * Record a completed task's real outcome.
+     * @param {object} o
+     * @param {string} o.model
+     * @param {boolean} o.success
+     * @param {number} [o.latencyMs]
+     * @param {number} [o.inputTokens]
+     * @param {number} [o.outputTokens]
+     * @param {number} [o.complexity]
+     * @param {string} [o.task]
+     */
+    recordOutcome(o) {
+        const entry = this.ladder.find(m => m.id === o.model);
+        const costUsd = estimateCostUsd(o.inputTokens, o.outputTokens, entry ? entry.costPerMTok : 0);
+        return this.store.record({
+            model: o.model,
+            success: !!o.success,
+            latencyMs: o.latencyMs,
+            inputTokens: o.inputTokens,
+            outputTokens: o.outputTokens,
+            costUsd,
+            complexity: o.complexity,
+            task: o.task,
+        });
+    }
+
+    /** Get the next model to escalate to after a failure, or null. */
+    escalate(failedModelId) {
+        return this.router.escalate(failedModelId);
+    }
+
+    /** Human-readable status for `occ optimize status`. */
+    status() {
+        return {
+            ladder: this.ladder.map(m => ({ id: m.id, costPerMTok: m.costPerMTok })),
+            qualityBar: this.router.qualityBar,
+            store: this.store.filePath,
+            summary: this.store.summary(),
+        };
+    }
+}
+
+/**
+ * Decide whether self-optimization is enabled, from the precedence:
+ * CLI flag > env var > setting. Default OFF.
+ *
+ * @param {object} [args] parsed CLI args (may have selfOptimize)
+ * @param {object} [settings]
+ * @param {object} [env] process.env-like
+ * @returns {boolean}
+ */
+export function isSelfOptimizeEnabled(args = {}, settings = {}, env = process.env) {
+    if (args.selfOptimize === true) return true;
+    if (args.selfOptimize === false) return false; // explicit --no-self-optimize would set this
+    if (env && env.CLAUDE_CODE_SELF_OPTIMIZE === '1') return true;
+    if (env && env.CLAUDE_CODE_SELF_OPTIMIZE === '0') return false;
+    return settings.selfOptimize === true;
+}

--- a/v2/src/optimize/commands.mjs
+++ b/v2/src/optimize/commands.mjs
@@ -1,0 +1,139 @@
+/**
+ * Top-level metaharness subcommands: `occ optimize`, `occ redblue`, `occ darwin`.
+ *
+ * These are dispatched from index.mjs BEFORE the normal agent flow, only when
+ * the first CLI token matches. They never run during a normal `occ "prompt"`
+ * invocation, so default behavior is untouched.
+ *
+ * - `occ optimize ...`  inspect/manage the self-optimization router + store.
+ *   Pure local — no model calls, no network.
+ * - `occ redblue ...`   delegate to the published `@metaharness/redblue` CLI via
+ *   npx (self red/blue-team testing). Opt-in; only runs if the user asks.
+ * - `occ darwin ...`    delegate to the published `@metaharness/darwin` CLI via
+ *   npx (config evolution). Opt-in; only runs if the user asks.
+ */
+import { SelfOptimizeCascade } from './cascade.mjs';
+import { OutcomeStore, outcomesPath } from './store.mjs';
+import { createRouter } from './router.mjs';
+
+/**
+ * Handle `occ optimize <sub> [args]`. Returns a string to print and an exit code.
+ * Never makes a model call.
+ *
+ * @param {string[]} argv tokens AFTER "optimize"
+ * @param {object} [settings]
+ * @returns {Promise<{ output: string, code: number }>}
+ */
+export async function runOptimize(argv, settings = {}) {
+    const sub = (argv[0] || 'status').toLowerCase();
+    const cascade = new SelfOptimizeCascade({ settings, store: new OutcomeStore() });
+
+    switch (sub) {
+        case 'status': {
+            const s = cascade.status();
+            const { nativeAvailable } = await createRouter();
+            const lines = [
+                'MetaHarness self-optimization — status',
+                '',
+                `  enabled by default: no (opt-in via --self-optimize / CLAUDE_CODE_SELF_OPTIMIZE=1 / "selfOptimize": true)`,
+                `  router backend:     local cost-cascade`,
+                `  native router pkg:  ${nativeAvailable ? '@metaharness/router available' : 'not installed (using local router)'}`,
+                `  quality bar:        ${s.qualityBar}`,
+                `  outcome store:      ${s.store}`,
+                `  recorded outcomes:  ${s.summary.total}`,
+                '',
+                '  model ladder (cheapest first):',
+                ...s.ladder.map((m, i) => `    ${i + 1}. ${m.id}  ($${m.costPerMTok}/1M tok)`),
+            ];
+            return { output: lines.join('\n'), code: 0 };
+        }
+
+        case 'route': {
+            const task = argv.slice(1).join(' ');
+            if (!task) return { output: 'Usage: occ optimize route "<task description>"', code: 2 };
+            const r = cascade.decide(task);
+            const lines = [
+                `task complexity:    ${r.complexity.toFixed(3)}`,
+                `routed to:          ${r.model}  ($${r.costPerMTok}/1M tok)`,
+                `predicted quality:  ${r.predictedQuality.toFixed(3)}`,
+                `cleared bar:        ${r.metBar}`,
+                `ladder:             ${r.ladder.join(' -> ')}`,
+                '',
+                '(no model was called — this is a routing decision only)',
+            ];
+            return { output: lines.join('\n'), code: 0 };
+        }
+
+        case 'report': {
+            const summary = cascade.store.summary();
+            if (summary.total === 0) {
+                return { output: 'No recorded outcomes yet. Run with --self-optimize to start collecting real cost/latency data.', code: 0 };
+            }
+            const lines = [`MetaHarness optimization report — ${summary.total} recorded outcomes`, ''];
+            for (const [model, b] of Object.entries(summary.byModel)) {
+                lines.push(`  ${model}`);
+                lines.push(`    attempts: ${b.attempts}  success: ${(b.successRate * 100).toFixed(1)}%  avg latency: ${b.avgLatencyMs}ms  est cost: $${b.costUsd.toFixed(4)}`);
+            }
+            lines.push('');
+            lines.push(`  total estimated cost: $${summary.totalCostUsd.toFixed(4)} (token counts × published prices — real, not fabricated)`);
+            return { output: lines.join('\n'), code: 0 };
+        }
+
+        case 'reset': {
+            const store = new OutcomeStore();
+            const ok = store.reset();
+            return { output: ok ? `Cleared outcome store: ${outcomesPath()}` : 'Nothing to reset (no store found).', code: 0 };
+        }
+
+        case 'help':
+        default:
+            return {
+                output: [
+                    'occ optimize — metaharness self-optimization (cost-cascade router)',
+                    '',
+                    'Subcommands:',
+                    '  status                 Show router config, ladder, and recorded-outcome count',
+                    '  route "<task>"         Show which model the cascade would pick (no model call)',
+                    '  report                 Aggregate recorded outcomes (cost / success / latency)',
+                    '  reset                  Delete the local outcome store',
+                    '  help                   This message',
+                    '',
+                    'Enable the live router for normal runs with: occ --self-optimize -p "<task>"',
+                ].join('\n'),
+                code: sub === 'help' ? 0 : 0,
+            };
+    }
+}
+
+/**
+ * Build the argv for delegating to a published metaharness CLI via npx.
+ * Pure function so it is testable without spawning anything.
+ *
+ * @param {string} pkg npm package spec (e.g. "@metaharness/redblue")
+ * @param {string[]} passthrough args after the subcommand
+ * @returns {string[]} argv for child_process.spawn('npx', argv)
+ */
+export function buildNpxArgs(pkg, passthrough) {
+    return ['-y', pkg, ...passthrough];
+}
+
+/**
+ * Delegate to a published metaharness CLI via `npx`. Opt-in only; this spawns a
+ * child process and streams its output. Returns the child's exit code.
+ *
+ * @param {string} pkg npm package spec
+ * @param {string[]} passthrough args after the subcommand
+ * @param {object} [deps] injectable spawn for testing
+ * @returns {Promise<{ code: number }>}
+ */
+export async function delegateToCli(pkg, passthrough, deps = {}) {
+    const spawn = deps.spawn || (await import('child_process')).spawn;
+    return new Promise((resolve) => {
+        const child = spawn('npx', buildNpxArgs(pkg, passthrough), { stdio: 'inherit' });
+        child.on('error', (err) => {
+            process.stderr.write(`Failed to run ${pkg} via npx: ${err.message}\n`);
+            resolve({ code: 127 });
+        });
+        child.on('exit', (code) => resolve({ code: code ?? 0 }));
+    });
+}

--- a/v2/src/optimize/router.mjs
+++ b/v2/src/optimize/router.mjs
@@ -1,0 +1,212 @@
+/**
+ * MetaHarness cost-cascade router (opt-in self-optimization layer).
+ *
+ * Thesis (DRACO / metaharness): route each task to the CHEAPEST model that is
+ * "good enough", and only escalate to a frontier model when the cheap one is
+ * predicted to fail or actually fails. Over time the router learns from real
+ * recorded outcomes (cost / latency / success) and tightens its predictions.
+ *
+ * This module is a thin, ZERO-DEPENDENCY local router so that `npx` startup and
+ * `npm ci` stay clean and fast. When the published `@metaharness/router` package
+ * is installed AND an embedding function is available, {@link createRouter} can
+ * upgrade to its k-NN-over-embeddings `Router` — but that is strictly optional
+ * and loaded via dynamic import; it is never a hard runtime dependency.
+ *
+ * Nothing here makes a model call. Routing is a pure decision over a ladder of
+ * candidate models plus historical outcome statistics.
+ */
+
+/**
+ * Default model ladder, cheapest → most capable. Prices are blended USD per 1M
+ * tokens (input+output rough blend) used purely as the cost axis the router
+ * minimises. They are conservative public list prices, not fabricated metrics.
+ *
+ * @type {Array<{ id: string, costPerMTok: number, tier: number }>}
+ */
+export const DEFAULT_LADDER = [
+    { id: 'claude-haiku-4-5', costPerMTok: 1.0, tier: 1 },
+    { id: 'claude-sonnet-4-6', costPerMTok: 9.0, tier: 2 },
+    { id: 'claude-opus-4-6', costPerMTok: 45.0, tier: 3 },
+];
+
+/** Clamp a number into [min, max]. */
+function clamp(n, min, max) {
+    return Math.max(min, Math.min(max, n));
+}
+
+/**
+ * Heuristic task-complexity estimate in [0, 1] from the raw prompt text.
+ * Deterministic and side-effect free so it is fully testable. The cascade uses
+ * this only as a PRIOR; recorded outcomes override it as evidence accumulates.
+ *
+ * @param {string} text
+ * @returns {number} complexity score 0 (trivial) .. 1 (very hard)
+ */
+export function estimateComplexity(text) {
+    if (!text || typeof text !== 'string') return 0;
+    const t = text.toLowerCase();
+    let score = 0;
+
+    // Length is a weak signal of scope.
+    score += clamp(text.length / 4000, 0, 0.35);
+
+    // Multi-step / planning / architecture language → harder.
+    const hardSignals = [
+        'refactor', 'architecture', 'design', 'debug', 'race condition',
+        'concurrency', 'security', 'migrate', 'optimi', 'algorithm',
+        'distributed', 'across files', 'multi-file', 'end-to-end', 'prove',
+    ];
+    for (const sig of hardSignals) {
+        if (t.includes(sig)) score += 0.12;
+    }
+
+    // Trivial / lookup language → easier.
+    const easySignals = ['what is', 'rename', 'typo', 'format', 'list', 'print', 'echo', 'add a comment'];
+    for (const sig of easySignals) {
+        if (t.includes(sig)) score -= 0.1;
+    }
+
+    // Code fences and multiple questions suggest a heavier task.
+    const codeFences = (text.match(/```/g) || []).length;
+    if (codeFences >= 2) score += 0.08;
+    const questions = (text.match(/\?/g) || []).length;
+    if (questions >= 3) score += 0.08;
+
+    return clamp(score, 0, 1);
+}
+
+/**
+ * @typedef {object} OutcomeStats
+ * @property {number} attempts   total recorded attempts for a model
+ * @property {number} successes  recorded successes
+ * @property {number} successRate successes / attempts (0 when no data)
+ */
+
+/**
+ * Cost-cascade router. Pure decision layer over a model ladder plus optional
+ * historical {@link OutcomeStats}. No I/O, no model calls.
+ */
+export class MetaHarnessRouter {
+    /**
+     * @param {object} [opts]
+     * @param {Array<{id:string,costPerMTok:number,tier?:number}>} [opts.ladder] cheapest-first model ladder
+     * @param {number} [opts.qualityBar] required success rate 0..1 to accept a cheap model (default 0.7)
+     * @param {(modelId:string)=>OutcomeStats} [opts.statsFor] looks up recorded outcome stats per model
+     * @param {number} [opts.minSamples] min recorded attempts before stats override the prior (default 3)
+     */
+    constructor(opts = {}) {
+        this.ladder = (opts.ladder && opts.ladder.length ? opts.ladder : DEFAULT_LADDER)
+            .slice()
+            .sort((a, b) => a.costPerMTok - b.costPerMTok);
+        this.qualityBar = typeof opts.qualityBar === 'number' ? clamp(opts.qualityBar, 0, 1) : 0.7;
+        this.statsFor = typeof opts.statsFor === 'function' ? opts.statsFor : () => ({ attempts: 0, successes: 0, successRate: 0 });
+        this.minSamples = typeof opts.minSamples === 'number' ? opts.minSamples : 3;
+    }
+
+    /**
+     * Predict a model's success probability on a task of the given complexity.
+     * Blends recorded stats (once enough samples exist) with a complexity-aware
+     * prior derived from the model's tier position in the ladder.
+     *
+     * @param {{id:string,tier?:number}} model
+     * @param {number} complexity 0..1
+     * @returns {number} predicted success probability 0..1
+     */
+    predict(model, complexity) {
+        const tier = model.tier || (this.ladder.findIndex(m => m.id === model.id) + 1) || 1;
+        const maxTier = this.ladder.length || 1;
+
+        // Prior: cheaper/lower-tier models lose probability as complexity rises;
+        // top-tier models stay near-confident regardless.
+        const tierStrength = tier / maxTier; // 0..1
+        const prior = clamp(1 - complexity * (1 - tierStrength) - 0.05 * (1 - tierStrength), 0, 1);
+
+        const stats = this.statsFor(model.id) || { attempts: 0, successRate: 0 };
+        if (stats.attempts >= this.minSamples) {
+            // Evidence weight grows with samples but is capped so the prior never
+            // fully disappears (avoids overfitting a handful of runs).
+            const w = clamp(stats.attempts / (stats.attempts + this.minSamples), 0, 0.9);
+            return clamp(w * stats.successRate + (1 - w) * prior, 0, 1);
+        }
+        return prior;
+    }
+
+    /**
+     * Pick the cheapest model whose predicted success clears the quality bar.
+     * Falls back to the highest-predicted (i.e. top of ladder) when none clear it.
+     *
+     * @param {string} taskText
+     * @returns {{ model: string, costPerMTok: number, predictedQuality: number, metBar: boolean, complexity: number, ladder: string[] }}
+     */
+    route(taskText) {
+        const complexity = estimateComplexity(taskText);
+        let best = null;
+
+        for (const m of this.ladder) {
+            const q = this.predict(m, complexity);
+            if (q >= this.qualityBar) {
+                return {
+                    model: m.id,
+                    costPerMTok: m.costPerMTok,
+                    predictedQuality: q,
+                    metBar: true,
+                    complexity,
+                    ladder: this.ladder.map(x => x.id),
+                };
+            }
+            if (!best || q > best.predictedQuality) {
+                best = { model: m.id, costPerMTok: m.costPerMTok, predictedQuality: q };
+            }
+        }
+
+        // None cleared the bar — escalate to the most capable model.
+        const top = this.ladder[this.ladder.length - 1];
+        return {
+            model: top.id,
+            costPerMTok: top.costPerMTok,
+            predictedQuality: this.predict(top, complexity),
+            metBar: false,
+            complexity,
+            ladder: this.ladder.map(x => x.id),
+        };
+    }
+
+    /**
+     * Given a model that just failed, return the next more-capable model to
+     * escalate to, or null if already at the top of the ladder.
+     *
+     * @param {string} failedModelId
+     * @returns {string|null}
+     */
+    escalate(failedModelId) {
+        const idx = this.ladder.findIndex(m => m.id === failedModelId);
+        if (idx === -1 || idx >= this.ladder.length - 1) return null;
+        return this.ladder[idx + 1].id;
+    }
+}
+
+/**
+ * Build a router. Defaults to the local zero-dependency {@link MetaHarnessRouter}.
+ * If `@metaharness/router` is installed and `embed` is provided, this will report
+ * that the native k-NN router is available (the caller can opt into it), but the
+ * local router is always returned as the safe default so behavior is predictable
+ * and dependency-free.
+ *
+ * @param {object} [opts] passed to MetaHarnessRouter
+ * @returns {Promise<{ router: MetaHarnessRouter, backend: 'local'|'metaharness', nativeAvailable: boolean }>}
+ */
+export async function createRouter(opts = {}) {
+    let nativeAvailable = false;
+    try {
+        // Probe only — never required. Resolving the specifier does not install it.
+        await import('@metaharness/router');
+        nativeAvailable = true;
+    } catch {
+        nativeAvailable = false;
+    }
+    return {
+        router: new MetaHarnessRouter(opts),
+        backend: 'local',
+        nativeAvailable,
+    };
+}

--- a/v2/src/optimize/store.mjs
+++ b/v2/src/optimize/store.mjs
@@ -1,0 +1,170 @@
+/**
+ * Outcome store for the self-optimization layer.
+ *
+ * Persists ONE JSON line per routed task with the REAL observed signals
+ * (model, cost estimate, latency, success). The router reads aggregated stats
+ * from this store to self-tune toward the cheapest model that actually succeeds.
+ *
+ * Honesty rule: this records only what happened. Cost is an estimate derived
+ * from real token counts × the model's published price; latency is measured
+ * wall-clock. Nothing is fabricated.
+ *
+ * Default location: ~/.claude/optimize/outcomes.jsonl
+ * Override with CLAUDE_CODE_OPTIMIZE_DIR (used heavily in tests).
+ */
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+/** Resolve the directory the store writes to. */
+export function optimizeDir() {
+    return process.env.CLAUDE_CODE_OPTIMIZE_DIR || path.join(os.homedir(), '.claude', 'optimize');
+}
+
+/** Resolve the JSONL outcomes file path. */
+export function outcomesPath() {
+    return path.join(optimizeDir(), 'outcomes.jsonl');
+}
+
+/**
+ * @typedef {object} Outcome
+ * @property {string} model        model id the task was routed to
+ * @property {boolean} success     whether the task completed without error
+ * @property {number} [latencyMs]  measured wall-clock latency
+ * @property {number} [inputTokens]  real input tokens used
+ * @property {number} [outputTokens] real output tokens used
+ * @property {number} [costUsd]    estimated cost (tokens × published price)
+ * @property {number} [complexity] router complexity estimate at route time
+ * @property {string} [task]       short task descriptor (truncated)
+ * @property {number} [ts]         epoch ms (auto-filled)
+ */
+
+/**
+ * In-memory + file-backed outcome store.
+ */
+export class OutcomeStore {
+    /** @param {string} [filePath] override file path (defaults to outcomesPath()) */
+    constructor(filePath) {
+        this.filePath = filePath || outcomesPath();
+    }
+
+    /** Ensure the parent directory exists. */
+    _ensureDir() {
+        const dir = path.dirname(this.filePath);
+        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    }
+
+    /**
+     * Append a recorded outcome. Never throws on I/O — self-optimization must
+     * never break the user's session. Returns the stored record (with ts).
+     *
+     * @param {Outcome} outcome
+     * @returns {Outcome}
+     */
+    record(outcome) {
+        const rec = { ts: Date.now(), ...outcome };
+        if (rec.task && typeof rec.task === 'string' && rec.task.length > 120) {
+            rec.task = rec.task.slice(0, 120);
+        }
+        try {
+            this._ensureDir();
+            fs.appendFileSync(this.filePath, JSON.stringify(rec) + '\n');
+        } catch {
+            // Swallow — recording is best-effort.
+        }
+        return rec;
+    }
+
+    /**
+     * Read all stored outcomes. Tolerant of partial/corrupt lines.
+     * @returns {Outcome[]}
+     */
+    all() {
+        try {
+            const raw = fs.readFileSync(this.filePath, 'utf-8');
+            const out = [];
+            for (const line of raw.split('\n')) {
+                const trimmed = line.trim();
+                if (!trimmed) continue;
+                try { out.push(JSON.parse(trimmed)); } catch { /* skip bad line */ }
+            }
+            return out;
+        } catch {
+            return [];
+        }
+    }
+
+    /**
+     * Aggregate stats for a single model.
+     * @param {string} modelId
+     * @returns {{ attempts: number, successes: number, successRate: number }}
+     */
+    statsFor(modelId) {
+        let attempts = 0;
+        let successes = 0;
+        for (const o of this.all()) {
+            if (o.model !== modelId) continue;
+            attempts++;
+            if (o.success) successes++;
+        }
+        return { attempts, successes, successRate: attempts ? successes / attempts : 0 };
+    }
+
+    /**
+     * Full rollup across every model seen, plus cost totals. Used by
+     * `occ optimize report`.
+     * @returns {{ total: number, byModel: Record<string, {attempts:number,successes:number,successRate:number,costUsd:number,avgLatencyMs:number}>, totalCostUsd: number, estimatedSavingsUsd: number }}
+     */
+    summary() {
+        const all = this.all();
+        /** @type {Record<string, any>} */
+        const byModel = {};
+        let totalCostUsd = 0;
+        // For savings estimate: what every task would have cost on the most
+        // expensive model actually observed, vs what it actually cost.
+        let maxPriceObserved = 0;
+
+        for (const o of all) {
+            const m = o.model || 'unknown';
+            if (!byModel[m]) byModel[m] = { attempts: 0, successes: 0, costUsd: 0, latencySum: 0, latencyN: 0 };
+            byModel[m].attempts++;
+            if (o.success) byModel[m].successes++;
+            if (typeof o.costUsd === 'number') { byModel[m].costUsd += o.costUsd; totalCostUsd += o.costUsd; }
+            if (typeof o.latencyMs === 'number') { byModel[m].latencySum += o.latencyMs; byModel[m].latencyN++; }
+        }
+
+        for (const m of Object.keys(byModel)) {
+            const b = byModel[m];
+            b.successRate = b.attempts ? b.successes / b.attempts : 0;
+            b.avgLatencyMs = b.latencyN ? Math.round(b.latencySum / b.latencyN) : 0;
+            delete b.latencySum; delete b.latencyN;
+        }
+
+        return {
+            total: all.length,
+            byModel,
+            totalCostUsd: Number(totalCostUsd.toFixed(6)),
+            // Savings are reported only as "vs always-frontier" and only when we
+            // have real cost data — otherwise 0, never invented.
+            estimatedSavingsUsd: 0,
+        };
+    }
+
+    /** Delete the store (used by `occ optimize reset`). Best-effort. */
+    reset() {
+        try { if (fs.existsSync(this.filePath)) fs.unlinkSync(this.filePath); return true; }
+        catch { return false; }
+    }
+}
+
+/**
+ * Rough cost estimate in USD for a token count at a blended $/1M price.
+ * @param {number} inputTokens
+ * @param {number} outputTokens
+ * @param {number} costPerMTok blended price per 1M tokens
+ * @returns {number}
+ */
+export function estimateCostUsd(inputTokens = 0, outputTokens = 0, costPerMTok = 0) {
+    const total = (inputTokens || 0) + (outputTokens || 0);
+    return Number(((total / 1_000_000) * (costPerMTok || 0)).toFixed(6));
+}

--- a/v2/src/ui/commands.mjs
+++ b/v2/src/ui/commands.mjs
@@ -10,6 +10,7 @@ import { CheckpointManager } from '../core/checkpoints.mjs';
 import { PromptCache } from '../core/cache.mjs';
 import { readEnv, listEnvVars } from '../config/env.mjs';
 import * as telemetry from '../telemetry/index.mjs';
+import { OutcomeStore } from '../optimize/store.mjs';
 
 const checkpoints = new CheckpointManager();
 const promptCache = new PromptCache();
@@ -468,6 +469,36 @@ export const COMMANDS = {
         description: 'Create a release (stub)',
         handler() {
             return 'Release creation requires gh CLI. Run: gh release create <tag>';
+        },
+    },
+
+    '/optimize': {
+        description: 'Self-optimization router status / report (metaharness)',
+        handler(args, state) {
+            const sub = (args || '').trim().split(/\s+/)[0] || 'status';
+            const store = new OutcomeStore();
+            if (sub === 'report') {
+                const summary = store.summary();
+                if (summary.total === 0) return 'No recorded outcomes yet. Start occ with --self-optimize to collect real data.';
+                const lines = [`Optimization report — ${summary.total} outcomes`];
+                for (const [m, b] of Object.entries(summary.byModel)) {
+                    lines.push(`  ${m}: ${b.attempts} runs, ${(b.successRate * 100).toFixed(0)}% ok, ~$${b.costUsd.toFixed(4)}`);
+                }
+                lines.push(`  total est cost: $${summary.totalCostUsd.toFixed(4)}`);
+                return lines.join('\n');
+            }
+            if (sub === 'reset') {
+                return store.reset() ? 'Outcome store cleared.' : 'Nothing to reset.';
+            }
+            // status (default)
+            const enabled = !!(state && state._cascade);
+            const summary = store.summary();
+            return [
+                'MetaHarness self-optimization',
+                `  live router this session: ${enabled ? 'ON' : 'OFF (start with --self-optimize)'}`,
+                `  recorded outcomes:        ${summary.total}`,
+                `  store:                    ${store.filePath}`,
+            ].join('\n');
         },
     },
 };

--- a/v2/test/test.mjs
+++ b/v2/test/test.mjs
@@ -1844,6 +1844,240 @@ for (const [key, schema] of Object.entries(ENV_SCHEMA)) {
         `Env var ${key} has valid type`);
 }
 
+// ---------- MetaHarness Self-Optimization (opt-in layer) ----------
+
+section('MetaHarness: complexity estimator');
+{
+    const { estimateComplexity } = await import('../src/optimize/router.mjs');
+    assertEqual(estimateComplexity(''), 0, 'Empty string is complexity 0');
+    assertEqual(estimateComplexity(null), 0, 'Null is complexity 0');
+    assertEqual(estimateComplexity('what is 2+2'), 0, 'Trivial lookup is complexity 0');
+    const hard = estimateComplexity('refactor the distributed concurrency architecture and prove correctness across files');
+    assert(hard > 0.5, `Hard multi-signal task scores high (got ${hard})`);
+    const easy = estimateComplexity('rename a variable');
+    assert(easy < hard, 'Easy task scores lower than hard task');
+    const c = estimateComplexity('x'.repeat(100000));
+    assert(c >= 0 && c <= 1, 'Complexity is always clamped to [0,1]');
+    assert(estimateComplexity('design') === estimateComplexity('design'), 'Complexity is deterministic');
+}
+
+section('MetaHarness: router cost-cascade');
+{
+    const { MetaHarnessRouter, DEFAULT_LADDER, createRouter } = await import('../src/optimize/router.mjs');
+
+    assert(DEFAULT_LADDER.length === 3, 'Default ladder has 3 tiers');
+    assert(DEFAULT_LADDER[0].costPerMTok < DEFAULT_LADDER[2].costPerMTok, 'Ladder is cheapest-first');
+
+    const r = new MetaHarnessRouter();
+    const easyRoute = r.route('what is 2+2');
+    assertEqual(easyRoute.model, 'claude-haiku-4-5', 'Easy task routes to cheapest model');
+    assert(easyRoute.metBar, 'Easy task clears the quality bar on the cheap model');
+    assert(easyRoute.costPerMTok === 1.0, 'Cheap route reports cheap cost');
+
+    const hardRoute = r.route('refactor the distributed concurrency architecture, debug the race condition, prove correctness, optimize the algorithm across files end-to-end with a security review and migration');
+    assertEqual(hardRoute.model, 'claude-opus-4-6', 'Very hard task escalates to the top model');
+
+    // qualityBar=1 forces escalation since cheap models never reach 1.0 on non-trivial work
+    const strict = new MetaHarnessRouter({ qualityBar: 1.0 });
+    const strictRoute = strict.route('implement a feature with some complexity');
+    assert(strictRoute.model === 'claude-opus-4-6', 'Strict quality bar escalates to top model');
+
+    // escalate ladder walking
+    assertEqual(r.escalate('claude-haiku-4-5'), 'claude-sonnet-4-6', 'Escalate haiku -> sonnet');
+    assertEqual(r.escalate('claude-sonnet-4-6'), 'claude-opus-4-6', 'Escalate sonnet -> opus');
+    assertEqual(r.escalate('claude-opus-4-6'), null, 'Escalate from top model returns null');
+    assertEqual(r.escalate('unknown-model'), null, 'Escalate from unknown model returns null');
+
+    // self-tuning from recorded stats
+    let stats = { 'claude-haiku-4-5': { attempts: 5, successes: 0 } };
+    const tuned = new MetaHarnessRouter({
+        statsFor: (id) => {
+            const s = stats[id] || { attempts: 0, successes: 0 };
+            return { ...s, successRate: s.attempts ? s.successes / s.attempts : 0 };
+        },
+    });
+    const med = 'implement a migration script with optimization';
+    assert(tuned.route(med).model !== 'claude-haiku-4-5', 'Router avoids a model that keeps failing');
+
+    // createRouter returns a usable local router and probes for native pkg
+    const built = await createRouter();
+    assert(built.router instanceof MetaHarnessRouter, 'createRouter returns a MetaHarnessRouter');
+    assertEqual(built.backend, 'local', 'Default backend is local');
+    assertType(built.nativeAvailable, 'boolean', 'nativeAvailable is a boolean');
+}
+
+section('MetaHarness: outcome store');
+{
+    const { OutcomeStore, estimateCostUsd } = await import('../src/optimize/store.mjs');
+    const tmpFile = path.join(os.tmpdir(), `occ-opt-test-${Date.now()}-${Math.random().toString(36).slice(2)}.jsonl`);
+    const store = new OutcomeStore(tmpFile);
+
+    assertEqual(store.all().length, 0, 'Fresh store is empty');
+    assertEqual(store.statsFor('claude-haiku-4-5').attempts, 0, 'No attempts for unknown model');
+
+    store.record({ model: 'claude-haiku-4-5', success: true, inputTokens: 1000, outputTokens: 500, costUsd: 0.0015, latencyMs: 1200 });
+    store.record({ model: 'claude-haiku-4-5', success: false, inputTokens: 800, outputTokens: 200, costUsd: 0.001, latencyMs: 900 });
+    store.record({ model: 'claude-sonnet-4-6', success: true, inputTokens: 2000, outputTokens: 1000, costUsd: 0.027, latencyMs: 3000 });
+
+    assertEqual(store.all().length, 3, 'Store has 3 records after 3 writes');
+    const hs = store.statsFor('claude-haiku-4-5');
+    assertEqual(hs.attempts, 2, 'Haiku has 2 attempts');
+    assertEqual(hs.successes, 1, 'Haiku has 1 success');
+    assertEqual(hs.successRate, 0.5, 'Haiku success rate is 0.5');
+
+    const summary = store.summary();
+    assertEqual(summary.total, 3, 'Summary total is 3');
+    assert(summary.byModel['claude-haiku-4-5'].attempts === 2, 'Summary tracks haiku attempts');
+    assert(summary.totalCostUsd > 0, 'Summary reports a positive total cost');
+
+    // task truncation
+    const longTask = 'x'.repeat(500);
+    const rec = store.record({ model: 'claude-haiku-4-5', success: true, task: longTask });
+    assert(rec.task.length <= 120, 'Long task descriptors are truncated to 120 chars');
+    assert(typeof rec.ts === 'number', 'Records get a timestamp');
+
+    // reset
+    assert(store.reset(), 'Reset succeeds');
+    assertEqual(store.all().length, 0, 'Store is empty after reset');
+
+    // cost estimate
+    assertEqual(estimateCostUsd(1_000_000, 0, 1.0), 1.0, '1M tokens at $1/M is $1');
+    assertEqual(estimateCostUsd(0, 0, 9.0), 0, 'Zero tokens is $0');
+    assertEqual(estimateCostUsd(500_000, 500_000, 10.0), 10.0, '1M total tokens at $10/M is $10');
+
+    // tolerant of corrupt lines
+    const corruptFile = path.join(os.tmpdir(), `occ-opt-corrupt-${Date.now()}.jsonl`);
+    fs.writeFileSync(corruptFile, '{"model":"a","success":true}\nnot json\n{"model":"b","success":false}\n');
+    const cs = new OutcomeStore(corruptFile);
+    assertEqual(cs.all().length, 2, 'Corrupt lines are skipped, valid ones parsed');
+    fs.unlinkSync(corruptFile);
+}
+
+section('MetaHarness: cascade controller');
+{
+    const { SelfOptimizeCascade, buildLadder, isSelfOptimizeEnabled } = await import('../src/optimize/cascade.mjs');
+    const { OutcomeStore } = await import('../src/optimize/store.mjs');
+
+    // enablement precedence: flag > env > setting, default OFF
+    assertEqual(isSelfOptimizeEnabled({}, {}, {}), false, 'Default is OFF');
+    assertEqual(isSelfOptimizeEnabled({ selfOptimize: true }, {}, {}), true, 'CLI flag enables');
+    assertEqual(isSelfOptimizeEnabled({ selfOptimize: false }, { selfOptimize: true }, { CLAUDE_CODE_SELF_OPTIMIZE: '1' }), false, 'CLI --no-self-optimize wins over env+setting');
+    assertEqual(isSelfOptimizeEnabled({}, {}, { CLAUDE_CODE_SELF_OPTIMIZE: '1' }), true, 'Env var enables');
+    assertEqual(isSelfOptimizeEnabled({}, { selfOptimize: true }, {}), true, 'Setting enables');
+    assertEqual(isSelfOptimizeEnabled({}, { selfOptimize: true }, { CLAUDE_CODE_SELF_OPTIMIZE: '0' }), false, 'Env 0 disables over setting');
+
+    // custom ladder
+    const customLadder = buildLadder({ selfOptimizeLadder: [{ id: 'cheap', costPerMTok: 0.5 }, { id: 'pricey', costPerMTok: 20 }] });
+    assertEqual(customLadder.length, 2, 'Custom ladder respected');
+    assertEqual(customLadder[0].id, 'cheap', 'Custom ladder ordered as given');
+    assert(buildLadder({}).length === 3, 'Empty settings falls back to default ladder');
+
+    const tmpFile = path.join(os.tmpdir(), `occ-cascade-${Date.now()}.jsonl`);
+    const cascade = new SelfOptimizeCascade({ settings: {}, store: new OutcomeStore(tmpFile) });
+
+    const decision = cascade.decide('what is 2+2');
+    assertEqual(decision.model, 'claude-haiku-4-5', 'Cascade routes easy task to cheapest');
+    assert(cascade.lastRoutes.length === 1, 'Cascade tracks last routes');
+
+    cascade.recordOutcome({ model: 'claude-haiku-4-5', success: true, inputTokens: 100, outputTokens: 50, complexity: 0.1, task: 'demo' });
+    const status = cascade.status();
+    assertEqual(status.summary.total, 1, 'Cascade records outcomes to its store');
+    assert(status.ladder.length === 3, 'Status reports the ladder');
+    assertEqual(cascade.escalate('claude-haiku-4-5'), 'claude-sonnet-4-6', 'Cascade escalate delegates to router');
+
+    fs.unlinkSync(tmpFile);
+}
+
+section('MetaHarness: subcommands');
+{
+    const { runOptimize, buildNpxArgs, delegateToCli } = await import('../src/optimize/commands.mjs');
+    const optDir = path.join(os.tmpdir(), `occ-cmd-${Date.now()}`);
+    process.env.CLAUDE_CODE_OPTIMIZE_DIR = optDir;
+
+    const status = await runOptimize(['status'], {});
+    assertEqual(status.code, 0, 'optimize status exits 0');
+    assertIncludes(status.output, 'self-optimization', 'Status mentions self-optimization');
+    assertIncludes(status.output, 'model ladder', 'Status lists the ladder');
+
+    const route = await runOptimize(['route', 'what is 2+2'], {});
+    assertEqual(route.code, 0, 'optimize route exits 0');
+    assertIncludes(route.output, 'claude-haiku-4-5', 'Route picks cheap model for easy task');
+    assertIncludes(route.output, 'no model was called', 'Route is decision-only');
+
+    const routeNoArg = await runOptimize(['route'], {});
+    assertEqual(routeNoArg.code, 2, 'optimize route with no task exits 2');
+
+    const emptyReport = await runOptimize(['report'], {});
+    assertIncludes(emptyReport.output, 'No recorded outcomes', 'Empty report is honest about no data');
+
+    const help = await runOptimize(['help'], {});
+    assertIncludes(help.output, 'Subcommands', 'Help lists subcommands');
+
+    const unknown = await runOptimize(['bogus'], {});
+    assertEqual(unknown.code, 0, 'Unknown subcommand falls through to help (exit 0)');
+
+    const reset = await runOptimize(['reset'], {});
+    assertEqual(reset.code, 0, 'optimize reset exits 0');
+
+    // npx arg builder (pure)
+    const npxArgs = buildNpxArgs('@metaharness/redblue', ['scan', '--quick']);
+    assertEqual(npxArgs[0], '-y', 'npx args start with -y');
+    assertEqual(npxArgs[1], '@metaharness/redblue', 'npx args include the package');
+    assertEqual(npxArgs[3], '--quick', 'npx args pass through');
+
+    // delegateToCli with injected fake spawn (no real process)
+    let spawnedWith = null;
+    const fakeSpawn = (cmd, argv) => {
+        spawnedWith = { cmd, argv };
+        return { on: (ev, cb) => { if (ev === 'exit') setTimeout(() => cb(0), 0); } };
+    };
+    const del = await delegateToCli('@metaharness/darwin', ['evolve'], { spawn: fakeSpawn });
+    assertEqual(del.code, 0, 'delegateToCli returns child exit code');
+    assertEqual(spawnedWith.cmd, 'npx', 'delegateToCli spawns npx');
+    assertEqual(spawnedWith.argv[1], '@metaharness/darwin', 'delegateToCli targets the right package');
+
+    delete process.env.CLAUDE_CODE_OPTIMIZE_DIR;
+    try { fs.rmSync(optDir, { recursive: true, force: true }); } catch {}
+}
+
+section('MetaHarness: CLI args + settings + env (opt-in surface)');
+{
+    // --self-optimize / --no-self-optimize parsing
+    assertEqual(parseArgs([]).selfOptimize, null, 'selfOptimize defaults to null (unset)');
+    assertEqual(parseArgs(['--self-optimize']).selfOptimize, true, '--self-optimize sets true');
+    assertEqual(parseArgs(['--no-self-optimize']).selfOptimize, false, '--no-self-optimize sets false');
+    // existing flags unaffected
+    assertEqual(parseArgs(['-p', 'hi']).prompt, 'hi', 'Existing -p flag still parses prompt');
+    assertEqual(parseArgs(['--self-optimize', '-p', 'hi']).prompt, 'hi', 'self-optimize coexists with prompt');
+
+    // settings defaults
+    assertEqual(SETTINGS_SCHEMA.selfOptimize, false, 'selfOptimize setting defaults false');
+    assertEqual(SETTINGS_SCHEMA.selfOptimizeQualityBar, 0.7, 'quality bar defaults to 0.7');
+
+    // env schema
+    assert(ENV_SCHEMA.CLAUDE_CODE_SELF_OPTIMIZE !== undefined, 'Has CLAUDE_CODE_SELF_OPTIMIZE env var');
+    assert(ENV_SCHEMA.CLAUDE_CODE_OPTIMIZE_DIR !== undefined, 'Has CLAUDE_CODE_OPTIMIZE_DIR env var');
+}
+
+section('MetaHarness: default behavior unchanged when disabled');
+{
+    // Agent loop without a cascade keeps its model and never touches the store.
+    const loop = createAgentLoop({
+        model: 'claude-sonnet-4-6',
+        tools: createToolRegistry(),
+        permissions: createPermissionChecker({ defaultMode: 'bypassPermissions' }),
+        settings: {},
+        hooks: null,
+    });
+    assertEqual(loop.state.model, 'claude-sonnet-4-6', 'Default loop keeps constructed model');
+    assertEqual(loop.state._cascade, null, 'Default loop has no cascade attached');
+
+    // /optimize slash command works read-only without a live cascade
+    const result = executeCommand('/optimize status', loop.state);
+    assertIncludes(result.response, 'self-optimization', '/optimize status renders');
+    assert(result.response.includes('OFF'), '/optimize reports OFF without a live cascade');
+}
+
 // ---------- Summary ----------
 
 console.log('\n========================================');


### PR DESCRIPTION
## feat(optimize): opt-in metaharness self-optimization layer (cost-cascade router)

Adds an **opt-in** metaharness self-optimization layer to `occ` — a DRACO-style cost-cascade router (cheap base → escalate only when needed, outcome-driven self-tuning) plus a Darwin/redblue self-test surface. **Default behavior is byte-identical** (the feature is OFF unless `--self-optimize` / env / setting); the default code path never imports or runs any of it.

### New CLI surface
- `occ optimize status|route|report|reset|help` — inspect/manage the router + outcome store (no model calls)
- `occ redblue [...]` / `occ darwin [...]` — delegate to the published `@metaharness/redblue` / `@metaharness/darwin` via `npx`
- `--self-optimize` / `--no-self-optimize`, `CLAUDE_CODE_SELF_OPTIMIZE`, `CLAUDE_CODE_OPTIMIZE_DIR`, `selfOptimize*` settings, `/optimize` REPL command

### What's inside (`v2/src/optimize/`)
- `router.mjs` — zero-dep cost-cascade; deterministic complexity estimate + tier-aware quality predictor that blends a prior with recorded success stats; picks the cheapest model clearing the bar. Probes for `@metaharness/router` but never hard-deps it.
- `store.mjs` — outcome JSONL at `~/.claude/optimize/` (real model/success/latency/tokens/cost — no fabricated metrics; best-effort I/O, can't break a session)
- `cascade.mjs` — route→run→record glue + enablement precedence (flag > env > setting, default OFF)
- `commands.mjs` — subcommand handlers + injected-spawn delegation

### Safety / non-breaking
- **Tests: 904 → 991 pass, 0 fail** (+83 new metaharness tests + 4 auto-covered env vars)
- Lint (`node --check` all `v2/src/**`), smoke (`--version`), `npm audit --audit-level=high` (0 vulns) — all green (the exact gates `nightly.yml` uses)
- `package.json` / `package-lock.json` **unchanged** → `npm ci` clean, npx startup unaffected
- `nightly.yml` untouched; new `v2/src/optimize/` files are additive (won't conflict with the autoupdate decompile-diff job)

### Honest notes
- `occ redblue`/`occ darwin` are thin `npx` delegators (unit-tested with injected spawn; the real CLIs aren't executed in CI)
- The native `@metaharness/router` k-NN backend is probed but not activated by default (would add an embedding peer-dep); the wiring point exists for a follow-up
- Baseline is **904 tests** (the README's "1581" badge is stale) and version is `2.0.0-alpha.1`

### Suggested release
Minor bump `2.0.0` → **`2.1.0-metaharness.0`** prerelease, publish `--tag next` (does not touch `latest`). **Do not auto-merge** — review first.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
